### PR TITLE
Only include examples.cmake if the examples option is turned on

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,7 +61,9 @@ if( BGFX_BUILD_TOOLS )
 	include( cmake/tools.cmake )
 endif()
 
-include( cmake/examples.cmake )
+if ( BGFX_BUILD_EXAMPLES )
+	include( cmake/examples.cmake )
+endif()
 
 if( BGFX_INSTALL )
 	include(GNUInstallDirs)


### PR DESCRIPTION
I'm trying to trim the examples folder out of the npm package because it is huge, but as is the `examples.cmake` file gets included even when the `BGFX_BUILD_EXAMPLES` option is turned off, which causes the build to fail. This makes it so that we don't try to include that cmake file when the option is off.