### PR TITLE
Exclude MinGW compat headers when building Android using MinGW cmake compiler

### DIFF
--- a/cmake/bx.cmake
+++ b/cmake/bx.cmake
@@ -45,7 +45,7 @@ target_include_directories( bx
 # Build system specific configurations
 if( MSVC )
 	target_include_directories( bx PUBLIC $<BUILD_INTERFACE:${BX_DIR}/include/compat/msvc> )
-elseif( MINGW )
+elseif( MINGW AND NOT ANDROID )
 	target_include_directories( bx PUBLIC $<BUILD_INTERFACE:${BX_DIR}/include/compat/mingw> )
 elseif( APPLE )
 	target_include_directories( bx PUBLIC $<BUILD_INTERFACE:${BX_DIR}/include/compat/osx> )


### PR DESCRIPTION
Add variable check to not include MinGW headers when building for Android using MinGW cmake compiler, preventing a clash with NDK libc++ headers.