### PR TITLE
Removed minz from bimg_decode

### DIFF
--- a/cmake/bimg/bimg_decode.cmake
+++ b/cmake/bimg/bimg_decode.cmake
@@ -21,7 +21,6 @@ file(
 	${BIMG_DIR}/src/image_decode.* #
 	#
 	${LOADPNG_SOURCES} #
-	${MINIZ_SOURCES} #
 )
 
 add_library(bimg_decode STATIC ${BIMG_DECODE_SOURCES})


### PR DESCRIPTION
Minz is currently included as source in both bimg and bimg_decode. Depending on the compiler settings this can cause symbols duplication issues when both libraries are linked into an executable or dynamic library. bimg_decode can not be used without bimg so we are moving minz source code to be only included in bimg to avoid this duplication. 