### PR TITLE
Moving minz to separate target. 

### DIFF
--- a/cmake/bimg/3rdparty/miniz.cmake
+++ b/cmake/bimg/3rdparty/miniz.cmake
@@ -16,8 +16,13 @@ endif()
 
 if(NOT MINIZ_LIBRARIES)
 	file(GLOB_RECURSE #
-		 MINIZ_SOURCES #
+		 MINIZ_SOURCES_INTERNAL #
 		 ${BIMG_DIR}/3rdparty/tinyexr/deps/miniz/miniz.* #
 	)
 	set(MINIZ_INCLUDE_DIR ${BIMG_DIR}/3rdparty/tinyexr/deps/miniz)
+
+	add_library(minz STATIC ${MINIZ_SOURCES_INTERNAL})
+	target_include_directories(minz PUBLIC ${MINIZ_INCLUDE_DIR})
+	set_target_properties(minz PROPERTIES FOLDER "bgfx/3rdparty")
+	set(MINIZ_LIBRARIES minz)
 endif()


### PR DESCRIPTION
Since minz is used by both bimg and bimg_decode the only way to always make it work no matter math the linker configuration is to move it to be a standalone target. This way symbols will be kept in the minz static lib and handled accordingly by the linker. 